### PR TITLE
CVE-2016-1238: avoid loading optional modules from .

### DIFF
--- a/lib/File/Fetch.pm
+++ b/lib/File/Fetch.pm
@@ -573,6 +573,8 @@ sub _lwp_fetch {
         $use_list->{'LWP::Protocol::https'} = '0';
     }
 
+    local @INC = @INC;
+    pop @INC if $INC[-1] eq '.';
     unless( can_load( modules => $use_list ) ) {
         $METHOD_FAIL->{'lwp'} = 1;
         return;
@@ -630,6 +632,8 @@ sub _httptiny_fetch {
 
     };
 
+    local @INC = @INC;
+    pop @INC if $INC[-1] eq '.';
     unless( can_load(modules => $use_list) ) {
         $METHOD_FAIL->{'httptiny'} = 1;
         return;
@@ -669,6 +673,8 @@ sub _httplite_fetch {
         'MIME::Base64'  => '0',
     };
 
+    local @INC = @INC;
+    pop @INC if $INC[-1] eq '.';
     unless( can_load(modules => $use_list) ) {
         $METHOD_FAIL->{'httplite'} = 1;
         return;
@@ -749,6 +755,8 @@ sub _iosock_fetch {
         'IO::Select'       => '0.0',
     };
 
+    local @INC = @INC;
+    pop @INC if $INC[-1] eq '.';
     unless( can_load(modules => $use_list) ) {
         $METHOD_FAIL->{'iosock'} = 1;
         return;
@@ -832,6 +840,8 @@ sub _netftp_fetch {
     ### required modules ###
     my $use_list = { 'Net::FTP' => 0 };
 
+    local @INC = @INC;
+    pop @INC if $INC[-1] eq '.';
     unless( can_load( modules => $use_list ) ) {
         $METHOD_FAIL->{'netftp'} = 1;
         return;


### PR DESCRIPTION
The final . in @INC can be used by an attacker to fake an optional
module for a process using File::Fetch if that module isn't installed.

This change temporarily removes . from @INC when loading optional
modules to prevent this attack.
