### PR TITLE
Add support for HTTP Basic auth in httplite, iosock, and lynx.

### DIFF
--- a/t/01_File-Fetch.t
+++ b/t/01_File-Fetch.t
@@ -203,7 +203,7 @@ for my $entry (@map) {
 {   for my $uri ( 'http://www.cpan.org/index.html',
                   'http://www.cpan.org/index.html?q=1',
                   'http://www.cpan.org/index.html?q=1&y=2',
-                  #'http://user:passwd@httpbin.org/basic-auth/user/passwd',
+                  'http://user:passwd@httpbin.org/basic-auth/user/passwd',
     ) {
         for (qw[lwp httptiny wget curl lftp fetch lynx httplite iosock]) {
             _fetch_uri( http => $uri, $_ );


### PR DESCRIPTION
The HTTP Basic authentication test (disabled in d0b0813b36102d16418fac086cba90dc023dc5cd / 0.52) was constantly failing because the underlying feature was not properly implemented in httplite, lynx, or iosock.

This PR re-enables the test and adds the functionality to those methods.

The problem with the 'httplite' method was due to a bug in the HTTP::Lite module that incorrectly parses URLs with a userinfo portion. I've raised neilb/HTTP-Lite#2 for that. In the meantime, this works around the issue by rebuilding the URL without the userinfo portion (since it's passed in via a request header anyway).

The 'iosock' method was never getting the userinfo because of the way the interface works, so I've added the request header for that, too.

And lynx, for some reason, requires the userinfo to be passed via the command-line. It seems to allow it in the URL, but it doesn't actually make use of the information there.