### PR TITLE
Support non-canonical URI for HTTP(S)

### DIFF
--- a/lib/File/Fetch.pm
+++ b/lib/File/Fetch.pm
@@ -400,9 +400,12 @@ sub _parse_uri {
         ### rebuild the path from the leftover parts;
         $href->{path} = join '/', '', splice( @parts, $index, $#parts );
 
-    } else {
+    } elsif ( $href->{scheme} eq 'http' || $href->{scheme} eq 'https' ) {
         ### using anything but qw() in hash slices may produce warnings
         ### in older perls :-(
+        @{$href}{ qw(userinfo host path) } = $uri =~ m|(?:([^\@:]*:[^\:\@]*)@)?([^/]*)(/.*)?$|s;
+        $href->{path} = '/' unless defined $href->{path};
+    } else {
         @{$href}{ qw(userinfo host path) } = $uri =~ m|(?:([^\@:]*:[^\:\@]*)@)?([^/]*)(/.*)$|s;
     }
 

--- a/t/01_File-Fetch.t
+++ b/t/01_File-Fetch.t
@@ -77,6 +77,12 @@ my @map = (
         path    => '/tmp/',
         file    => 'index.txt',
     },
+    {   uri     => 'http://localhost',   # non-canonical URI
+        scheme  => 'http',
+        host    => 'localhost',
+        path    => '/',                  # default path is '/'
+        file    => '',
+    },
 
     ### only test host part, the rest is OS dependant
     {   uri     => 'file://localhost/tmp/index.txt',
@@ -200,7 +206,8 @@ for my $entry (@map) {
 }
 
 ### http:// tests ###
-{   for my $uri ( 'http://httpbin.org/html',
+{   for my $uri ( 'http://httpbin.org',
+                  'http://httpbin.org/html',
                   'http://httpbin.org/response-headers?q=1',
                   'http://httpbin.org/response-headers?q=1&y=2',
                   #'http://www.cpan.org/index.html?q=1&y=2',
@@ -300,11 +307,3 @@ sub _fetch_uri {
         }}
     }
 }
-
-
-
-
-
-
-
-


### PR DESCRIPTION
Sometimes HTTP(S) URI is non-canonical (in terms of [URI module](https://metacpan.org/pod/URI#$uri-%3Ecanonical)), with no trailing backslash. For example `http://httpbin.org` not `http://httpbin.org/`. Now `_parse_uri()` function can't parse non-canonical URIs. Fix it.
