### PR TITLE
wget: use --passive-ftp switch only for ftp scheme

### DIFF
--- a/lib/File/Fetch.pm
+++ b/lib/File/Fetch.pm
@@ -906,7 +906,7 @@ sub _wget_fetch {
     push(@$cmd, '--timeout=' . $TIMEOUT) if $TIMEOUT;
 
     ### run passive if specified ###
-    push @$cmd, '--passive-ftp' if $FTP_PASSIVE;
+    push @$cmd, '--passive-ftp' if $self->scheme eq 'ftp' && $FTP_PASSIVE;
 
     ### set the output document, add the uri ###
     push @$cmd, '--output-document', $to, $self->uri;


### PR DESCRIPTION
Without this change, --passive-ftp is passed to any invocation of wget,
even when fetching from http urls.

    $ perl -MFile::Fetch -E '$File::Fetch::BLACKLIST= [qw|LWP|]; \
        $File::Fetch::DEBUG=1; \
        $ff = File::Fetch->new(uri=>"https://www.cpan.org/src/5.0/perl-5.34.0.tar.gz"); \
        $ff->fetch()'
    Running [/usr/bin/wget --quiet --passive-ftp --output-document /tmp/perl-5.34.0.tar.gz https://www.cpan.org/src/5.0/perl-5.34.0.tar.gz]...