### PR TITLE
Point RFC links to ietf.org

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -161,7 +161,7 @@
   specific, so what a url means on one machine will
   mean something different on another.
   VMS is now treated according to RFC 1738 
-  (http://www.faqs.org/rfcs/rfc1738.html).
+  (https://datatracker.ietf.org/doc/html/rfc1738).
 
 0.13_02 Sun Nov  4 10:38:40 CET 2007
 

--- a/lib/File/Fetch.pm
+++ b/lib/File/Fetch.pm
@@ -359,7 +359,7 @@ sub _parse_uri {
     $href->{scheme} = $1;
 
     ### See rfc 1738 section 3.10
-    ### http://www.faqs.org/rfcs/rfc1738.html
+    ### https://datatracker.ietf.org/doc/html/rfc1738#section-3.10
     ### And wikipedia for more on windows file:// urls
     ### http://en.wikipedia.org/wiki/File://
     if( $href->{scheme} eq 'file' ) {
@@ -1315,7 +1315,7 @@ sub _fetch_fetch {
 
 ### use File::Copy for fetching file:// urls ###
 ###
-### See section 3.10 of RFC 1738 (http://www.faqs.org/rfcs/rfc1738.html)
+### See section 3.10 of RFC 1738 (https://datatracker.ietf.org/doc/html/rfc1738#section-3.10)
 ### Also see wikipedia on file:// (http://en.wikipedia.org/wiki/File://)
 ###
 
@@ -1698,7 +1698,7 @@ the C<URI::Escape> module from CPAN, and pre-encode your URI before
 passing it to C<File::Fetch>. You can read about the details of URIs
 and URI encoding here:
 
-  http://www.faqs.org/rfcs/rfc2396.html
+L<https://datatracker.ietf.org/doc/html/rfc2396>
 
 =head1 TODO
 


### PR DESCRIPTION
The faqs.org website has ads, is difficult to navigate and is not the
canonical source.

Also, change the link in the POD to be in L<> so it is correctly
hyperlinked, i.e. on https://perldoc.perl.org/File::Fetch#Files-I'm-trying-to-fetch-have-reserved-characters-or-non-ASCII-characters-in-them.-What-do-I-do?